### PR TITLE
Fix current production

### DIFF
--- a/index.js
+++ b/index.js
@@ -159,7 +159,7 @@ class envoyDevice {
     var me = this;
     let result = me.deviceStatusInfo.data;
     me.log.debug(result);
-    let wNow = parseFloat(result.production[1].wNow / 1000).toFixed(3);
+    let wNow = parseFloat(result.production[0].wNow / 1000).toFixed(3);
     if (wNow < 0) {
       wNow = 0;
     }


### PR DESCRIPTION
Suggestion to get wNow from `production[0]` rather than `production[1]`.

For me the envoy `production.json` looks like this (new installation June 2020, unmetered enphase envoy-s with 9 Enphase Microinverters and 9 panels, Firmware: R4.10.35):
```
 {
   "production":[
      {
         "type":"inverters",
         "activeCount":9,
         "readingTime":1592207066,
         "wNow":434,
         "whLifetime":63554
      },
      {
         "type":"eim",
         "activeCount":0,
         "measurementType":"production",
         "readingTime":1592207068,
         "wNow":0.0,
         "whLifetime":0.0,
         "varhLeadLifetime":0.0,
         "varhLagLifetime":0.0,
         "vahLifetime":0.0,
         "rmsCurrent":-0.0,
         "rmsVoltage":230.466,
         "reactPwr":0.0,
         "apprntPwr":-0.0,
         "pwrFactor":0.0,
         "whToday":0.0,
         "whLastSevenDays":0.0,
         "vahToday":0.0,
         "varhLeadToday":0.0,
         "varhLagToday":0.0
      }
   ],
   "consumption":[
      {
         "type":"eim",
         "activeCount":0,
         "measurementType":"total-consumption",
         "readingTime":1592207068,
         "wNow":-4.552,
         "whLifetime":0.0,
         "varhLeadLifetime":0.0,
         "varhLagLifetime":0.0,
         "vahLifetime":0.0,
         "rmsCurrent":-0.46,
         "rmsVoltage":238.219,
         "reactPwr":-0.0,
         "apprntPwr":-109.566,
         "pwrFactor":-1.0,
         "whToday":0.0,
         "whLastSevenDays":0.0,
         "vahToday":0.0,
         "varhLeadToday":0.0,
         "varhLagToday":0.0
      },
      {
         "type":"eim",
         "activeCount":0,
         "measurementType":"net-consumption",
         "readingTime":1592207068,
         "wNow":-4.552,
         "whLifetime":0.0,
         "varhLeadLifetime":0.0,
         "varhLagLifetime":0.0,
         "vahLifetime":0.0,
         "rmsCurrent":0.46,
         "rmsVoltage":245.971,
         "reactPwr":-0.0,
         "apprntPwr":59.334,
         "pwrFactor":-0.12,
         "whToday":0,
         "whLastSevenDays":0,
         "vahToday":0,
         "varhLeadToday":0,
         "varhLagToday":0
      }
   ],
   "storage":[
      {
         "type":"acb",
         "activeCount":0,
         "readingTime":0,
         "wNow":0,
         "whNow":0,
         "state":"idle"
      }
   ]
}
```