### PR TITLE
Fix typos in envoydevice.js

### DIFF
--- a/src/envoydevice.js
+++ b/src/envoydevice.js
@@ -2790,7 +2790,7 @@ class EnvoyDevice extends EventEmitter {
                 systemPvService.getCharacteristic(Characteristic.On)
                     .onGet(async () => {
                         const state = this.productionPowerState;
-                        const info = this.disableLogInfo ? false : this.emit('message', `Envoy: ${serialNumber}, production power state: ${state ? 'Avtive' : 'Not active'}`);
+                        const info = this.disableLogInfo ? false : this.emit('message', `Envoy: ${serialNumber}, production power state: ${state ? 'Active' : 'Not active'}`);
                         return state;
                     })
                     .onSet(async (state) => {
@@ -3277,7 +3277,7 @@ class EnvoyDevice extends EventEmitter {
                     this.productionPowerStateSensorService.getCharacteristic(Characteristic.ContactSensorState)
                         .onGet(async () => {
                             const state = this.productionPowerState;
-                            const info = this.disableLogInfo ? false : this.emit('message', `Production power state sensor: ${state ? 'Avtive' : 'Not active'}`);
+                            const info = this.disableLogInfo ? false : this.emit('message', `Production power state sensor: ${state ? 'Active' : 'Not active'}`);
                             return state;
                         });
                     accessory.addService(this.productionPowerStateSensorService);
@@ -3291,7 +3291,7 @@ class EnvoyDevice extends EventEmitter {
                     this.productionPowerPeakSensorService.getCharacteristic(Characteristic.ContactSensorState)
                         .onGet(async () => {
                             const state = this.productionPowerPeakDetected;
-                            const info = this.disableLogInfo ? false : this.emit('message', `Production power peak sensor: ${state ? 'Avtive' : 'Not active'}`);
+                            const info = this.disableLogInfo ? false : this.emit('message', `Production power peak sensor: ${state ? 'Active' : 'Not active'}`);
                             return state;
                         });
                     accessory.addService(this.productionPowerPeakSensorService);
@@ -3305,7 +3305,7 @@ class EnvoyDevice extends EventEmitter {
                     this.productionEnergyStateSensorService.getCharacteristic(Characteristic.ContactSensorState)
                         .onGet(async () => {
                             const state = this.productionEnergyState;
-                            const info = this.disableLogInfo ? false : this.emit('message', `Production energy state sensor: ${state ? 'Avtive' : 'Not active'}`);
+                            const info = this.disableLogInfo ? false : this.emit('message', `Production energy state sensor: ${state ? 'Active' : 'Not active'}`);
                             return state;
                         });
                     accessory.addService(this.productionEnergyStateSensorService);
@@ -3431,7 +3431,7 @@ class EnvoyDevice extends EventEmitter {
                             this.consumptionTotalPowerPeakSensorService.getCharacteristic(Characteristic.ContactSensorState)
                                 .onGet(async () => {
                                     const state = this.consumptionTotalPowerPeakDetected || false;
-                                    const info = this.disableLogInfo ? false : this.emit('message', `${consumptionMeasurmentType}, power peak sensor: ${state ? 'Avtive' : 'Not active'}`);
+                                    const info = this.disableLogInfo ? false : this.emit('message', `${consumptionMeasurmentType}, power peak sensor: ${state ? 'Active' : 'Not active'}`);
                                     return state;
                                 });
                             accessory.addService(this.consumptionTotalPowerPeakSensorService)
@@ -3445,7 +3445,7 @@ class EnvoyDevice extends EventEmitter {
                             this.consumptionNetPowerPeakSensorService.getCharacteristic(Characteristic.ContactSensorState)
                                 .onGet(async () => {
                                     const state = this.consumptionNetPowerPeakDetected || false;
-                                    const info = this.disableLogInfo ? false : this.emit('message', `${consumptionMeasurmentType}, power peak sensor: ${state ? 'Avtive' : 'Not active'}`);
+                                    const info = this.disableLogInfo ? false : this.emit('message', `${consumptionMeasurmentType}, power peak sensor: ${state ? 'Active' : 'Not active'}`);
                                     return state;
                                 });
                             accessory.addService(this.consumptionNetPowerPeakSensorService)


### PR DESCRIPTION
Was looking at the output logs and am proposing change of Avtive to Active


```
[9/10/2023, 9:25:49 AM] [enphaseEnvoy] Device: 192.168.1.106 Envoy, Envoy: XXXXXXXXXXX, production power state: **Avtive**
[9/10/2023, 9:25:49 AM] [enphaseEnvoy] Device: 192.168.1.106 Envoy, Envoy: XXXXXXXXXXX, production power level: 24.7 %
[9/10/2023, 9:25:49 AM] [enphaseEnvoy] Device: 192.168.1.106 Envoy, Production power state sensor: **Avtive**
[9/10/2023, 9:25:49 AM] [enphaseEnvoy] Device: 192.168.1.106 Envoy, Production energy state sensor: **Avtive**
[9/10/2023, 9:25:49 AM] [enphaseEnvoy] Device: 192.168.1.106 Envoy, Production energy level sensor: Active
[9/10/2023, 9:25:49 AM] [enphaseEnvoy] Device: 192.168.1.106 Envoy, Consumption (Total), power peak sensor: Not active
```