### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,6 +8,10 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@v8
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/grzegorz914/homebridge-enphase-envoy/security/code-scanning/1](https://github.com/grzegorz914/homebridge-enphase-envoy/security/code-scanning/1)

In general, this problem is fixed by explicitly setting a `permissions` block in the workflow (either at the root level or per job) that grants only the scopes needed by the job instead of inheriting broad repository defaults. For this stale-issues workflow, `actions/stale` needs to read and write issues and pull requests, and possibly interact with repository contents metadata, so a minimal, least-privilege configuration is to grant `contents: read`, `issues: write`, and `pull-requests: write`.

The single best fix here, without altering existing functionality, is to add a `permissions` block under the `stale` job (the job that currently has only `runs-on` and `steps`). That aligns with the CodeQL suggestion and documents permissions for this specific job only, without impacting other workflows. Concretely, in `.github/workflows/stale.yml`, directly under `runs-on: ubuntu-latest`, add:

```yaml
    permissions:
      contents: read
      issues: write
      pull-requests: write
```

No additional imports or external methods are required; this is purely a YAML configuration change within the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
